### PR TITLE
Accept sorting and listing options for all subreddits functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ func main() {
 		"gedditAgent v1",
 	)
 
+	// Set listing options
+	subOpts := geddit.ListingOptions{
+		Limit: 10,
+	}
+
 	// Get reddit's default frontpage
-	submissions, _ := session.DefaultFrontpage()
+	submissions, _ := session.DefaultFrontpage(geddit.DefaultPopularity, subOpts)
 
 	// Get our own personal frontpage
-	submissions, _ = session.Frontpage()
+	submissions, _ = session.Frontpage(geddit.DefaultPopularity, subOpts)
+
+	// Get specific subreddit submissions, sorted by new
+	submissions, _ = session.SubredditSubmissions("hockey", geddit.NewSubmissions, subOpts)
 
 	// Print title and author of each submission
 	for _, s := range submissions {

--- a/login_session.go
+++ b/login_session.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/google/go-querystring/query"
 )
 
 // LoginSession represents an HTTP session with reddit.com --
@@ -109,9 +111,16 @@ func (s LoginSession) Clear() error {
 }
 
 // Frontpage returns the submissions on the logged-in user's personal frontpage.
-func (s LoginSession) Frontpage() ([]*Submission, error) {
+func (s LoginSession) Frontpage(sort popularitySort, params ListingOptions) ([]*Submission, error) {
+	v, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
+	redditUrl := fmt.Sprintf("http://www.reddit.com/%s/.json?%s", sort, v.Encode())
+
 	req := request{
-		url:       "http://www.reddit.com/.json",
+		url:       redditUrl,
 		cookie:    s.cookie,
 		useragent: s.useragent,
 	}


### PR DESCRIPTION
Allow the user to provide sorting and listing options
for all subreddit functions, most notably Frontpage() and
DefaultFrontpage(). This change also removes SortedSubmissions(),
which was made obsolete now that subreddit functions consistently
accept the same options.

---

**MAJOR CHANGES. FEEDBACK WANTED.**

I was playing around with functions `DefaultFrontpage()` and `Frontpage()` when I noticed that I could not do usual subreddit actions like sorting and limiting.

After looking over the function `SortedSubmissions()`, I realized it might be better to provide the same arguments for all subreddit-type functions. Except, functions `DefaultFrontpage()` and `Frontpage()` would not need a `subreddit` argument.

I think this makes the library more consistent when dealing with subreddits, as the user can sort and provider any listing options supported by `ListingOptions`. This also makes `SortedSubmissions()` obsolete.

Please note that I am a total Go beginner. Please advise on any code improvements and I will happily push new commits as needed.