### PR TITLE
Fixed bug when calling LoginSession.Frontpage with DefaultPopularity

### DIFF
--- a/login_session.go
+++ b/login_session.go
@@ -125,7 +125,13 @@ func (s LoginSession) Frontpage(sort PopularitySort, params ListingOptions) ([]*
 		return nil, err
 	}
 
-	redditUrl := fmt.Sprintf("https://www.reddit.com/%s/.json?%s", sort, v.Encode())
+	var redditUrl string
+
+	if sort == DefaultPopularity {
+		redditUrl = fmt.Sprintf("https://www.reddit.com/.json?%s", v.Encode())
+	} else {
+		redditUrl = fmt.Sprintf("https://www.reddit.com/%s/.json?%s", sort, v.Encode())
+	}
 
 	req := request{
 		url:       redditUrl,


### PR DESCRIPTION
Trying to call Frontpage with the DefaultPopularity PopularitySort throws the following error:
`Get https://www.reddit.com//.json?limit=10: invalid request :path "//.json?limit=10"`

It looks like this was causes by the double slash in the URL generated since DefaultPopularity is an empty string. I just threw in a quick conditional check for this case and it's now working fine for me. You should be able to reproduce the error with
```
// session is a LoginSession created earlier
_, err := session.Frontpage(geddit.DefaultPopularity, geddit.ListingOptions{})
fmt.Printf("%v\n", err)
```
