### PR TITLE
Fixed missing OAuth Token validation

### DIFF
--- a/oauth_session.go
+++ b/oauth_session.go
@@ -93,6 +93,15 @@ func (o *OAuthSession) LoginAuth(username, password string) error {
 	if err != nil {
 		return err
 	}
+	if !t.Valid() {
+		msg := "Invalid OAuth token"
+		if t != nil {
+			if extra := t.Extra("error"); extra != nil {
+				msg = fmt.Sprintf("%s: %s", msg, extra)
+			}
+		}
+		return errors.New(msg)
+	}
 	o.Client = o.OAuthConfig.Client(o.ctx, t)
 	return nil
 }


### PR DESCRIPTION
The **OAuthSession.LoginAuth** function does not validate the token returned by [oauth2.Config.PasswordCredentialsToken](https://godoc.org/golang.org/x/oauth2#Config.PasswordCredentialsToken). It is not enough to check that there is no error, the token must be validated by using [oauth2.Token.Valid](https://godoc.org/golang.org/x/oauth2#Token.Valid).

If you try to call LoginAuth with wrong credentials, you will get an apparently valid token.