### PR TITLE
Add SelftextHTML field to Submission

### DIFF
--- a/submission.go
+++ b/submission.go
@@ -22,6 +22,7 @@ type Submission struct {
 	ID            string  `json:"id"`
 	Permalink     string  `json:"permalink"`
 	Selftext      string  `json:"selftext"`
+	SelftextHTML  string  `json:"selftext_html"`
 	ThumbnailURL  string  `json:"thumbnail"`
 	DateCreated   float64 `json:"created_utc"`
 	NumComments   int     `json:"num_comments"`


### PR DESCRIPTION
This PR adds the SelftextHTML field to the Submission structure. This field might be useful as you can use the plain text version and the HTML version of the selftext text as you need it.